### PR TITLE
fixed the bug for iterator traverse and added unit test

### DIFF
--- a/constant.go
+++ b/constant.go
@@ -1,0 +1,7 @@
+package tikv
+
+import "github.com/pkg/errors"
+
+var(
+	errNoMoreRequiredDataFromTikv = errors.New("no more data from tikv")
+)


### PR DESCRIPTION
fixed 4 bugs for tikv iterator:
1. when traversing the iterator backward, some error occers when fetching data from tikv server
2. when traversing the iterator forward out of range, it will not be able to be traversed backward
3. after bug2 was fixed, when traversing the iterator forward out of range, move the pointer backward, then the iterator is still no able to be traversed forward
4. when pointer of the iterator points to its last item, call its "next" function, it will still return true.